### PR TITLE
Added the same checks in the pipeline using github actions

### DIFF
--- a/.github/workflows/shift-left-quality-checks.yml
+++ b/.github/workflows/shift-left-quality-checks.yml
@@ -1,0 +1,10 @@
+name: Shift left quality checks
+on: [push, pull_request]
+jobs:
+  checks:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+    - run: sh ./shift-left-quality-checks.sh
+

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # Welcome to shift left quality discussion
 
-This is a hello world example, with a lot of checks in [configuration file](./pom.xml).
-
-The intent of this branch is to understand how/what are some checks done at desk.
-
-We highlight some of the features like spelling mistake & lint issues here.
+This is a hello world example, where we mimic quality at desk checks in a pipeline.
 
 ## Prerequisite
 
@@ -27,7 +23,7 @@ git clone git@github.com:dsvellal/shift-left-quality-sample.git
 Change to hello-world-feature-branch
 
 ```sh
-git checkout quality-at-desk
+git checkout pipeline-consistency
 ```
 
 Run the project checks locally

--- a/shift-left-quality-checks.sh
+++ b/shift-left-quality-checks.sh
@@ -8,6 +8,7 @@ run_check() {
      files=$(find . -name "*.${ext}" -not -path "./node_modules/*")
      echo "${files}" | xargs npx "${@}"
 }
+run_check yml yaml-lint
 run_check json jsonlint
 run_check sh shellcheck -e SC1017
 run_check md markdownlint-cli -c ./config/markdownlintcli_config.json


### PR DESCRIPTION
Adding pipeline checks inline with checks made by shift-left-quality-checks.sh. This will ensure that if anyone forgets to run shift-left-quality-checks.sh in their local environment, the pipeline catches any violations if it exists.